### PR TITLE
Arreglo para que no resetee el tamaño de ventana.

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -145,7 +145,6 @@
         });
 
         window.doc.on('loaded', function() {
-          window.doc.restore();
           window.doc.show();
           window.doc.focus();
           window.doc.requestAttention(true);


### PR DESCRIPTION
Borrada la linea windows.doc.restore() para evitar que resetee el tamaño de la ventana si esta maximizada al seguir un link.
